### PR TITLE
Make global Random use thread-safe

### DIFF
--- a/src/Moniker/NameGenerator.cs
+++ b/src/Moniker/NameGenerator.cs
@@ -77,7 +77,9 @@ namespace Moniker
 
         private static string GetRandomEntry(IReadOnlyList<string> entries)
         {
-            var index = Random.Next(entries.Count);
+            int index;
+            lock (Random)
+                index = Random.Next(entries.Count);
             return entries[index];
         }
     }


### PR DESCRIPTION
This PR fixes issue #2 by using a lock around the shared `Random` instance in `NameGenerator`.