### PR TITLE
perf: Compute disallowed result once

### DIFF
--- a/src/Moniker/NameGenerator.cs
+++ b/src/Moniker/NameGenerator.cs
@@ -60,12 +60,14 @@ namespace Moniker
 
             string result;
             var (disallowedAdjective, disallowedNoun) = disallowed;
+            var disallowedResult = $"{disallowedAdjective}{delimiter}{disallowedNoun}";
+
             do
             {
                 var adjective = GetRandomEntry(adjectives);
                 var noun = GetRandomEntry(nouns);
                 result = $"{adjective}{delimiter}{noun}";
-            } while (result == $"{disallowedAdjective}{delimiter}{disallowedNoun}");
+            } while (result == disallowedResult);
 
             return result;
         }


### PR DESCRIPTION
The disallowed result was computed on each iteration (causing a string allocation) of the `do-while` loop, which seems wasteful. This PR moves the computation of the disallowed result out of the loop.