### PR TITLE
docs: Fix README doc to mention .NET 8 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ thirsty-williamson
 objective-gould
 ```
 
-## .NET Standard Library
+## .NET Library
 
-To use the .NET Standard 2.0 library install the package from NuGet.
+To use the library (requires .NET 8 or later) install the package from NuGet.
 
 ```PowerShell
 Install-Package Moniker


### PR DESCRIPTION
In commit 728d13ed920bcb1e68fb4b3e25de305edb168c7e, the library was [changed to target .NET 8](https://github.com/alexmg/Moniker/commit/728d13ed920bcb1e68fb4b3e25de305edb168c7e#diff-0413930ebab23ea70df78ef94e41483172f2436cf5e0fa1ae7dd12cb83e38f25R5). This PR fixes the read-me document to be aligned with the change since it still mentioned .NET Standard 2 as the requirement.