### PR TITLE
perf: Add a zero-allocation version of the API

### DIFF
--- a/src/Moniker/Chars.cs
+++ b/src/Moniker/Chars.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Text;
+
+namespace Moniker;
+
+/// <summary>
+/// Represents a reference to a string of characters.
+/// </summary>
+public readonly ref struct Chars
+{
+    private readonly ReadOnlySpan<byte> _u8str;
+
+    internal Chars(ReadOnlySpan<byte> u8str, int charCount)
+    {
+        _u8str = u8str;
+        Length = charCount;
+    }
+
+    /// <summary>
+    /// The length in characters.
+    /// </summary>
+    public int Length { get; }
+
+    /// <summary>
+    /// The length when encoded in UTF-8 bytes.
+    /// </summary>
+    public int Utf8Length => _u8str.Length;
+
+    /// <summary>
+    /// Writes characters to the specified buffer.
+    /// </summary>
+    /// <param name="buffer">The buffer to write to.</param>
+    /// <returns>The number of characters written.</returns>
+    public int Write(Span<char> buffer)
+    {
+        var count = Length;
+        if (count > buffer.Length)
+            return 0;
+
+        Encoding.UTF8.GetChars(_u8str, buffer);
+        return count;
+    }
+
+    /// <summary>
+    /// Writes character in UTF-8 encoding to the specified buffer.
+    /// </summary>
+    /// <param name="buffer">The buffer to write to.</param>
+    /// <returns>The number of characters written.</returns>
+    public int WriteUtf8(Span<byte> buffer) =>
+        _u8str.TryCopyTo(buffer) ? Utf8Length : 0;
+
+    /// <summary>
+    /// Returns a string with the same characters.
+    /// </summary>
+    public override string ToString()
+    {
+        var chars = Length <= 64 ? stackalloc char[Length] : new char[Length];
+        _ = Write(chars);
+        return new(chars);
+    }
+
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
+
+    /// <summary>
+    /// This method is unsupported and throws <see cref="NotSupportedException"/>
+    /// because <seealso cref="Chars"/> instances cannot be boxed. Use
+    /// <see cref="op_Equality"/> instead.
+    /// </summary>
+    /// <exception cref="NotSupportedException">Always thrown.</exception>
+    [Obsolete("This method is unsupported and will always throw an exception. Use the equality operator instead.")]
+    public override bool Equals(object? obj) => throw new NotSupportedException();
+
+    /// <summary>
+    /// This method is unsupported and throws <see cref="NotSupportedException"/>.
+    /// </summary>
+    /// <exception cref="NotSupportedException">Always thrown.</exception>
+    [Obsolete("This method is unsupported and will always throw an exception.")]
+    public override int GetHashCode() => throw new NotSupportedException();
+
+#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
+
+    /// <summary>
+    /// Compares to another <see cref="Chars"/> for equality.
+    /// </summary>
+    /// <param name="other">The other <see cref="Chars"/> to compare to.</param>
+    /// <returns><see langword="true" /> if this instance compares equals to <paramref name="other"/>.</returns>
+    public bool Equals(Chars other) => _u8str.SequenceEqual(other._u8str);
+
+    internal bool Equals(ReadOnlySpan<byte> other) => _u8str.SequenceEqual(other);
+
+    /// <summary>
+    /// Compares two <see cref="Chars"/> for equality.
+    /// </summary>
+    /// <param name="left">First operand to compare.</param>
+    /// <param name="right">Second operand to compare.</param>
+    /// <returns><see langword="true" /> if <paramref name="left"/> equals <paramref name="right"/>.</returns>
+    public static bool operator ==(Chars left, Chars right) => left.Equals(right);
+
+    /// <summary>
+    /// Compares two <see cref="Chars"/> for inequality.
+    /// </summary>
+    /// <param name="left">First operand to compare.</param>
+    /// <param name="right">Second operand to compare.</param>
+    /// <returns><see langword="true" /> if <paramref name="left"/> does not equal <paramref name="right"/>.</returns>
+    public static bool operator !=(Chars left, Chars right) => !left.Equals(right);
+}

--- a/src/Moniker/Utf8Strings.cs
+++ b/src/Moniker/Utf8Strings.cs
@@ -6,32 +6,6 @@ using System.Text;
 
 namespace Moniker;
 
-internal readonly ref struct Utf8String(ReadOnlySpan<byte> bytes, int charCount)
-{
-    public readonly ReadOnlySpan<byte> Bytes = bytes;
-    public readonly int CharCount = charCount;
-
-    public int GetChars(Span<char> chars) => Encoding.UTF8.GetChars(Bytes, chars);
-
-    public override string ToString() => Encoding.UTF8.GetString(Bytes);
-
-    // Equality members
-
-    public static bool operator ==(Utf8String left, ReadOnlySpan<byte> right) => left.Equals(right);
-    public static bool operator !=(Utf8String left, ReadOnlySpan<byte> right) => !left.Equals(right);
-
-    private bool Equals(ReadOnlySpan<byte> other) => Bytes.SequenceEqual(other);
-
-    // Unsupported equality members because this type cannot be boxed
-
-    public override int GetHashCode() => throw new NotSupportedException();
-    public override bool Equals(object? obj) => throw new NotSupportedException();
-
-    // Implicit conversions
-
-    public static implicit operator ReadOnlySpan<byte>(Utf8String data) => data.Bytes;
-}
-
 internal readonly ref struct Utf8Strings
 {
     private readonly ReadOnlySpan<byte> _data;
@@ -52,7 +26,7 @@ internal readonly ref struct Utf8Strings
         _charCounts = charCounts;
     }
 
-    public Utf8String this[int index] => new(_data[_offsets[index].._offsets[index + 1]], _charCounts[index]);
+    public Chars this[int index] => new(_data[_offsets[index].._offsets[index + 1]], _charCounts[index]);
 
     public override string ToString() => $"{{ Count = {Count}, Size = {_data.Length} }}";
 
@@ -67,7 +41,7 @@ internal readonly ref struct Utf8Strings
         /// Behaviour is undefined if <see cref="MoveNext"/> has never been called or returned
         /// <see langword="false"/>.
         /// </remarks>
-        public Utf8String Current => _strings[_index];
+        public Chars Current => _strings[_index];
 
         public bool MoveNext()
         {

--- a/test/Moniker.ApprovalTests/Moniker.approved.txt
+++ b/test/Moniker.ApprovalTests/Moniker.approved.txt
@@ -1,5 +1,25 @@
 namespace Moniker
 {
+    [System.Obsolete("Types with embedded references are not supported in this version of your compiler" +
+        ".", true)]
+    [System.Runtime.CompilerServices.CompilerFeatureRequired("RefStructs")]
+    [System.Runtime.CompilerServices.IsByRefLike]
+    public readonly struct Chars
+    {
+        public int Length { get; }
+        public int Utf8Length { get; }
+        public bool Equals(Moniker.Chars other) { }
+        [System.Obsolete("This method is unsupported and will always throw an exception. Use the equality o" +
+            "perator instead.")]
+        public override bool Equals(object? obj) { }
+        [System.Obsolete("This method is unsupported and will always throw an exception.")]
+        public override int GetHashCode() { }
+        public override string ToString() { }
+        public int Write(System.Span<char> buffer) { }
+        public int WriteUtf8(System.Span<byte> buffer) { }
+        public static bool operator !=(Moniker.Chars left, Moniker.Chars right) { }
+        public static bool operator ==(Moniker.Chars left, Moniker.Chars right) { }
+    }
     public enum MonikerStyle
     {
         Moniker = 0,
@@ -9,7 +29,10 @@ namespace Moniker
     {
         public const string DefaultDelimiter = "-";
         public static string Generate(Moniker.MonikerStyle monikerStyle, string delimiter = "-") { }
+        public static void Generate(Moniker.MonikerStyle monikerStyle, out Moniker.Chars adjective, out Moniker.Chars noun) { }
         public static string GenerateMoby(string delimiter = "-") { }
+        public static void GenerateMoby(out Moniker.Chars adjective, out Moniker.Chars noun) { }
         public static string GenerateMoniker(string delimiter = "-") { }
+        public static void GenerateMoniker(out Moniker.Chars adjective, out Moniker.Chars noun) { }
     }
 }

--- a/test/Moniker.PerformanceTests/NameGeneratorBenchmark.cs
+++ b/test/Moniker.PerformanceTests/NameGeneratorBenchmark.cs
@@ -9,4 +9,10 @@ public class NameGeneratorBenchmark
 
     [Benchmark]
     public string GenerateMoniker() => NameGenerator.Generate(MonikerStyle.Moniker);
+
+    [Benchmark]
+    public void GenerateMobyPair() => NameGenerator.Generate(MonikerStyle.Moby, out _, out _);
+
+    [Benchmark]
+    public void GenerateMonikerPair() => NameGenerator.Generate(MonikerStyle.Moniker, out _, out _);
 }

--- a/test/Moniker.Tests/CharsTests.cs
+++ b/test/Moniker.Tests/CharsTests.cs
@@ -1,0 +1,155 @@
+﻿using System.Text;
+using System;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Moniker.Tests;
+
+public class CharsTests
+{
+    private static Chars Chars(string str) =>
+        new(Encoding.UTF8.GetBytes(str), str.Length);
+
+    [Theory]
+    [InlineData("foobar", 6, 6)]
+    [InlineData("☀️", 2, 6)]
+    [InlineData("🐟", 2, 4)]
+    [InlineData("⭐", 1, 3)]
+    [InlineData("🐕", 2, 4)]
+    public void Lengths(string str, int length, int utf8Length)
+    {
+        var chars = Chars(str);
+        chars.Length.Should().Be(length);
+        chars.Utf8Length.Should().Be(utf8Length);
+    }
+
+    [Theory]
+    [InlineData(6, "foobar")]
+    [InlineData(7, "foobar-")]
+    [InlineData(8, "foobar--")]
+    public void Write(int length, string expected)
+    {
+        var chars = Chars("foobar");
+        var buffer = new char[length];
+        buffer.AsSpan().Fill('-');
+
+        var result = chars.Write(buffer);
+
+        result.Should().Be(6);
+        new string(buffer).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    public void WriteWhenBufferIsTooSmall(int length)
+    {
+        var chars = Chars("foobar");
+        var buffer = new char[length];
+        buffer.AsSpan().Fill('-');
+
+        var result = chars.Write(buffer);
+
+        result.Should().Be(0);
+        new string('-', length).Should().Be(new string(buffer));
+    }
+
+    [Theory]
+    [InlineData(6, "foobar")]
+    [InlineData(7, "foobar-")]
+    [InlineData(8, "foobar--")]
+    public void WriteUtf8(int length, string expected)
+    {
+        var chars = Chars("foobar");
+        var buffer = new byte[length];
+        buffer.AsSpan().Fill((byte)'-');
+
+        var result = chars.WriteUtf8(buffer);
+
+        result.Should().Be(6);
+        Encoding.UTF8.GetString(buffer).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    public void WriteUtf8WhenBufferIsTooSmall(int length)
+    {
+        var chars = Chars("foobar");
+        var buffer = new byte[length];
+        buffer.AsSpan().Fill((byte)'-');
+
+        var result = chars.WriteUtf8(buffer);
+
+        result.Should().Be(0);
+        Encoding.UTF8.GetString(buffer).Should().Be(new string('-', length));
+    }
+
+    [Fact]
+    public void ToStringReturnsStringWithAllCharacters()
+    {
+        var samples = Enumerable.Range(0, 100)
+                                .Select(n => string.Join(string.Empty, Enumerable.Repeat("foobar", n)))
+                                .TakeWhile(s => s.Length <= 256);
+
+        foreach (var str in samples)
+            Chars(str).ToString().Should().Be(str);
+    }
+
+    [Fact]
+    public void EqualsComparesValues()
+    {
+        var chars1 = Chars("foobar");
+        var chars2 = Chars("foobar");
+        var chars3 = Chars("FOOBAR");
+        chars1.Equals(chars2).Should().BeTrue();
+        chars1.Equals(chars3).Should().BeFalse();
+    }
+
+    [Fact]
+    public void EqualityOperatorComparesValues()
+    {
+        var chars1 = Chars("foobar");
+        var chars2 = Chars("foobar");
+        var chars3 = Chars("FOOBAR");
+        (chars1 == chars2).Should().BeTrue();
+        (chars1 == chars3).Should().BeFalse();
+    }
+
+    [Fact]
+    public void InequalityOperatorComparesValues()
+    {
+        var chars1 = Chars("foobar");
+        var chars2 = Chars("foobar");
+        var chars3 = Chars("FOOBAR");
+        (chars1 != chars2).Should().BeFalse();
+        (chars1 != chars3).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetHashCodeIsUnsupported()
+    {
+        var act = () =>
+        {
+            var chars = Chars("foobar");
+            _ = chars.GetHashCode();
+        };
+
+        act.Should().Throw<NotSupportedException>();
+    }
+
+    [Fact]
+    public void EqualsIsUnsupported()
+    {
+        var act = () =>
+        {
+            var chars = Chars("foobar");
+            _ = chars.Equals(42);
+        };
+
+        act.Should().Throw<NotSupportedException>();
+    }
+}

--- a/test/Moniker.Tests/NameGeneratorTests.cs
+++ b/test/Moniker.Tests/NameGeneratorTests.cs
@@ -52,5 +52,34 @@ namespace Moniker.Tests
 
             moniker.Should().MatchRegex(expected);
         }
+
+        [Theory]
+        [InlineData(MonikerStyle.Moby)]
+        [InlineData(MonikerStyle.Moniker)]
+        public void GeneratePairWithSpecificMonikerStyleMethods(MonikerStyle monikerStyle)
+        {
+            Chars adjective, noun;
+
+            switch (monikerStyle)
+            {
+                case MonikerStyle.Moniker: NameGenerator.GenerateMoniker(out adjective, out noun); break;
+                case MonikerStyle.Moby: NameGenerator.GenerateMoby(out adjective, out noun); break;
+                default: throw new ArgumentOutOfRangeException(nameof(monikerStyle), monikerStyle, null);
+            };
+            const string expected = /* lang=regex */ "^[a-zA-Z]+$";
+            adjective.ToString().Should().MatchRegex(expected);
+            noun.ToString().Should().MatchRegex(expected);
+        }
+
+        [Theory]
+        [InlineData(MonikerStyle.Moby)]
+        [InlineData(MonikerStyle.Moniker)]
+        public void GeneratePairWithMonikerStyleParameter(MonikerStyle monikerStyle)
+        {
+            NameGenerator.Generate(monikerStyle, out var adjective, out var noun);
+            const string expected = /* lang=regex */ "^[a-zA-Z]+$";
+            adjective.ToString().Should().MatchRegex(expected);
+            noun.ToString().Should().MatchRegex(expected);
+        }
     }
 }

--- a/test/Moniker.Tests/StringDataTests.cs
+++ b/test/Moniker.Tests/StringDataTests.cs
@@ -66,15 +66,12 @@ public class StringDataTests
         var index = 0;
         using var line = lines.GetEnumerator();
 
-        foreach (var u8Str in strings)
+        foreach (var chars in strings)
         {
             line.MoveNext().Should().BeTrue();
-            var str = Encoding.UTF8.GetString(u8Str);
-            str.Should().Be(line.Current);
-            u8Str.ToString().Should().Be(line.Current);
-
-            strings[index].Bytes.SequenceEqual(u8Str).Should().BeTrue();
-            (u8Str == strings[index]).Should().BeTrue();
+            var str = chars.ToString();
+            chars.ToString().Should().Be(line.Current);
+            (chars == strings[index]).Should().BeTrue();
 
             // Except for some coincidental cases, ensure string isn't interned.
             // This list is not exhaustive and even may be brittle (subject to


### PR DESCRIPTION
This is a follow-up to PR #8 

> > Incidentally, do you care to also add this? This way, the allocation of string becomes the entire responsibility of the caller, but it will require a modest expansion to the public API. Let me know if you're interested and I can propose something for prosperity, when I am bored next.
>
> I'm interested.

This PR renames `Utf8String` to `Chars`, makes it (mostly) public, and adds the following new zero-allocation APIs:

```c#
public static void Generate(MonikerStyle monikerStyle, out Chars adjective, out Chars noun) { /* … */ }
public static void GenerateMoniker(out Chars adjective, out Chars noun) { /* … */ }
public static void GenerateMoby(out Chars adjective, out Chars noun) { /* … */ }
```

Unfortunately, since [generic value tuples](https://learn.microsoft.com/en-us/dotnet/api/system.valuetuple-2?view=net-8.0) cannot carry `Chars`, one cannot simply return `(Chars, Chars)` or `(Chars Adjective, Chars Noun)` so out parameters are used instead. The other way to solve this would be to introduce a `CharsPair` type, but that would just add more code to maintain and test, and bring marginal benefits (though it can always be done later too).

`Utf8String` is renamed to `Chars` to encapsulate how data is stored internally. It has methods that permit writing into `char` and UTF-8 `byte` buffers for those who care to avoid an allocation; for those who don't care can simply call `ToString()`.

The benchmarks are updated and show roughly a 5x performance increase and _zero_ allocations with the new members:

| Method              | Mean     | Error    | StdDev   | Median   | Gen0   | Allocated |
|-------------------- |---------:|---------:|---------:|---------:|-------:|----------:|
| GenerateMoby        | 58.53 ns | 0.783 ns | 0.694 ns | 58.51 ns | 0.0043 |      55 B |
| GenerateMoniker     | 59.96 ns | 1.762 ns | 5.166 ns | 57.31 ns | 0.0042 |      53 B |
| GenerateMobyPair    | 11.84 ns | 0.221 ns | 0.246 ns | 11.85 ns |      - |         - |
| GenerateMonikerPair | 12.44 ns | 0.271 ns | 0.535 ns | 12.22 ns |      - |         - |

---
- BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4037/23H2/2023Update/SunValley3)
- 13th Gen Intel Core i7-1370P, 1 CPU, 20 logical and 14 physical cores
- .NET SDK 8.0.400
  - [Host]     : .NET 8.0.8 (8.0.824.36612), X64 RyuJIT AVX2
  - DefaultJob : .NET 8.0.8 (8.0.824.36612), X64 RyuJIT AVX2
